### PR TITLE
Update eventloop-epoll.cc

### DIFF
--- a/lib/jf/eventloop-epoll.cc
+++ b/lib/jf/eventloop-epoll.cc
@@ -71,7 +71,7 @@ void EventLoop_epoll::unwatch_out(
 void EventLoop_epoll::run_one()
 {
     events_.resize(notifiers_.size());
-    int num_ready = ::epoll_wait(epoll_fd_, &events_[0], events_.size(), -1);
+    int num_ready = ::epoll_wait(epoll_fd_, &events_[0], events_.size(), 0);
     assert(num_ready != -1);
 
     for (int i=0; i<num_ready; i++) {


### PR DESCRIPTION
Hi Jörg,
in `int num_ready = ::epoll_wait(epoll_fd_, &events_[0], events_.size(), -1);` bewirkt timeout = -1, dass er blockt bis ein fd bereit ist. Ich denke er sollte die Funktion so schnell wie möglich verlasse, also timeout = 0.
